### PR TITLE
Dimitris/change dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.idea
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "1.0.2"
-source = "git+https://github.com/distributed-lab/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
+source = "git+https://github.com/zkVerify/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
 dependencies = [
  "anyhow",
  "hashbrown",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "1.0.0"
-source = "git+https://github.com/distributed-lab/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
+source = "git+https://github.com/zkVerify/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
 dependencies = [
  "anyhow",
  "itertools",
@@ -497,12 +497,12 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "1.0.0"
-source = "git+https://github.com/distributed-lab/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
+source = "git+https://github.com/zkVerify/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
 
 [[package]]
 name = "plonky2_util"
 version = "1.0.0"
-source = "git+https://github.com/distributed-lab/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
+source = "git+https://github.com/zkVerify/plonky2?branch=stable#c587c2e4b9350e29d7aecc1a02f6e35c33550839"
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "no-std", "blockchain", "cryptography"]
 resolver = "2"
 
 [dependencies]
-plonky2 = { git = "https://github.com/distributed-lab/plonky2", branch = "stable", default-features = false}
+plonky2 = { git = "https://github.com/zkVerify/plonky2", branch = "stable", default-features = false}
 snafu = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_with = { version = "3.12.0", default-features = false, features = ["macros", "hex"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "no-std", "blockchain", "cryptography"]
 resolver = "2"
 
 [dependencies]
-plonky2 = { git = "https://github.com/zkVerify/plonky2", branch = "stable", default-features = false}
+plonky2 = { git = "https://github.com/zkVerify/plonky2", tag = "v0.1.0", default-features = false}
 snafu = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_with = { version = "3.12.0", default-features = false, features = ["macros", "hex"] }


### PR DESCRIPTION
Changed dependency to the one within zkVerify and replaced stable with a tag to `v0.1.0` (created from the stable branch of [zkVerify/plonky2](https://github.com/zkVerify/plonky2/tree/stable)).